### PR TITLE
Fix export WEBHOOK in SETUP

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -63,7 +63,7 @@ To test your Four Keys deployment, you can generate mock data that simulates eve
 1. Export your event handler URL an environment variable. This is the webhook URL that will receive events:
 
     ```sh
-    export WEBHOOK=`gcloud run services list --project $PROJECT_ID | grep event-handler | awk '{print $4}'`
+    export WEBHOOK=`gcloud run services list --project $PROJECT_ID | grep event-handler- | awk '{print $2}'`
     ```
 
 1. Export your event handler secret to an environment variable. This is the secret used to authenticate events sent to the webhook:


### PR DESCRIPTION
Hi

this is output of `$ gcloud run services list --project $PROJECT_ID` in my Cloud Shell web console:

```
✔
SERVICE: event-handler
REGION: europe-central2
URL: https://event-handler-7fv...app
LAST DEPLOYED BY: email@
LAST DEPLOYED AT: 2023-02-20T11:40:48.915826Z

✔
SERVICE: fourkeys-github-parser
REGION: europe-central2
URL: https://fourkeys-github-parser-7fv...app
LAST DEPLOYED BY: email@
LAST DEPLOYED AT: 2023-02-20T11:41:24.943423Z

✔
SERVICE: fourkeys-gitlab-parser
REGION: europe-central2
URL: https://fourkeys-gitlab-parser-7fv...app
LAST DEPLOYED BY: email@
LAST DEPLOYED AT: 2023-02-20T12:13:31.312376Z

✔
SERVICE: fourkeys-grafana-dashboard
REGION: europe-central2
URL: https://fourkeys-grafana-dashboard-7fv...app
LAST DEPLOYED BY: email@
LAST DEPLOYED AT: 2023-02-20T12:25:24.890167Z
```

Command `gcloud run services list --project $PROJECT_ID | grep event-handler | awk '{print $4}'` returns empty string.

I use following command to get WEBHOOK URL in my Cloud Shell: 
```
export WEBHOOK=`gcloud run services list --project $PROJECT_ID | grep event-handler- | awk '{print $2}'`
```
_(there is an extra dash and different awk variable)_
