### PR TITLE
Allow overriding gcr.io domain to work around region limitations

### DIFF
--- a/bq-workers/argocd-parser/cloudbuild.yaml
+++ b/bq-workers/argocd-parser/cloudbuild.yaml
@@ -16,20 +16,20 @@ steps:
 - # Build argocd-parser image
   name: gcr.io/cloud-builders/docker:latest
   args: ['build', 
-         '--tag=gcr.io/$PROJECT_ID/argocd-parser:${_TAG}', '.']
+         '--tag=${_GCR_DOMAIN}/$PROJECT_ID/argocd-parser:${_TAG}', '.']
   dir: 'bq-workers/argocd-parser'
   id: build
 
 - # Push the container image to Artifact Registry
   name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/argocd-parser:${_TAG}']
+  args: ['push', '${_GCR_DOMAIN}/$PROJECT_ID/argocd-parser:${_TAG}']
   waitFor: build
   id: push
 
 - # Deploy to Cloud Run
   name: google/cloud-sdk
   args: ['gcloud', 'run', 'deploy', 'argocd-parser',
-         '--image', 'gcr.io/$PROJECT_ID/argocd-parser:${_TAG}',
+         '--image', '${_GCR_DOMAIN}/$PROJECT_ID/argocd-parser:${_TAG}',
          '--region', '${_REGION}',
          '--platform', 'managed'
   ]
@@ -37,5 +37,5 @@ steps:
   waitFor: push
 
 images: [
-  'gcr.io/$PROJECT_ID/argocd-parser:${_TAG}'
+  '${_GCR_DOMAIN}/$PROJECT_ID/argocd-parser:${_TAG}'
 ]

--- a/bq-workers/circleci-parser/cloudbuild.yaml
+++ b/bq-workers/circleci-parser/cloudbuild.yaml
@@ -16,19 +16,19 @@ steps:
 - # Build circleci worker image
   name: gcr.io/cloud-builders/docker:latest
   args: ['build', 
-         '--tag=gcr.io/$PROJECT_ID/circleci-parser', '.']
+         '--tag=${_GCR_DOMAIN}/$PROJECT_ID/circleci-parser', '.']
   id: build
 
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/circleci-parser']
+  args: ['push', '${_GCR_DOMAIN}/$PROJECT_ID/circleci-parser']
   waitFor: build
   id: push
 
 - # Deploy to Cloud Run
   name: google/cloud-sdk
   args: ['gcloud', 'run', 'deploy', 'circleci-parser',
-         '--image', 'gcr.io/$PROJECT_ID/circleci-parser',
+         '--image', '${_GCR_DOMAIN}/$PROJECT_ID/circleci-parser',
          '--region', '${_REGION}',
          '--platform', 'managed'
   ]
@@ -36,5 +36,5 @@ steps:
   waitFor: push
 
 images: [
-  'gcr.io/$PROJECT_ID/circleci-parser'
+  '${_GCR_DOMAIN}/$PROJECT_ID/circleci-parser'
 ]

--- a/bq-workers/cloud-build-parser/cloudbuild.yaml
+++ b/bq-workers/cloud-build-parser/cloudbuild.yaml
@@ -16,19 +16,19 @@ steps:
 - # Build cloud-build-parser image
   name: gcr.io/cloud-builders/docker:latest
   args: ['build', 
-         '--tag=gcr.io/$PROJECT_ID/cloud-build-parser:${_TAG}', '.']
+         '--tag=${_GCR_DOMAIN}/$PROJECT_ID/cloud-build-parser:${_TAG}', '.']
   id: build
 
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/cloud-build-parser:${_TAG}']
+  args: ['push', '${_GCR_DOMAIN}/$PROJECT_ID/cloud-build-parser:${_TAG}']
   waitFor: build
   id: push
 
 - # Deploy to Cloud Run
   name: google/cloud-sdk
   args: ['gcloud', 'run', 'deploy', 'cloud-build-parser',
-         '--image', 'gcr.io/$PROJECT_ID/cloud-build-parser:${_TAG}',
+         '--image', '${_GCR_DOMAIN}/$PROJECT_ID/cloud-build-parser:${_TAG}',
          '--region', '${_REGION}',
          '--platform', 'managed'
   ]
@@ -36,5 +36,5 @@ steps:
   waitFor: push
 
 images: [
-  'gcr.io/$PROJECT_ID/cloud-build-parser:${_TAG}'
+  '${_GCR_DOMAIN}/$PROJECT_ID/cloud-build-parser:${_TAG}'
 ]

--- a/bq-workers/github-parser/cloudbuild.yaml
+++ b/bq-workers/github-parser/cloudbuild.yaml
@@ -16,15 +16,15 @@ steps:
 - # Build github-parser image
   name: gcr.io/cloud-builders/docker:latest
   args: ['build', 
-         '--tag=gcr.io/$PROJECT_ID/github-parser:${_TAG}', '.']
+         '--tag=${_GCR_DOMAIN}/$PROJECT_ID/github-parser:${_TAG}', '.']
   id: build
 
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/github-parser:${_TAG}']
+  args: ['push', '${_GCR_DOMAIN}/$PROJECT_ID/github-parser:${_TAG}']
   waitFor: build
   id: push
 
 images: [
-  'gcr.io/$PROJECT_ID/github-parser:${_TAG}'
+  '${_GCR_DOMAIN}/$PROJECT_ID/github-parser:${_TAG}'
 ]

--- a/bq-workers/gitlab-parser/cloudbuild.yaml
+++ b/bq-workers/gitlab-parser/cloudbuild.yaml
@@ -16,19 +16,19 @@ steps:
 - # Build new-source worker image
   name: gcr.io/cloud-builders/docker:latest
   args: ['build', 
-         '--tag=gcr.io/$PROJECT_ID/gitlab-parser:${_TAG}', '.']
+         '--tag=${_GCR_DOMAIN}/$PROJECT_ID/gitlab-parser:${_TAG}', '.']
   id: build
 
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/gitlab-parser:${_TAG}']
+  args: ['push', '${_GCR_DOMAIN}/$PROJECT_ID/gitlab-parser:${_TAG}']
   waitFor: build
   id: push
 
 - # Deploy to Cloud Run
   name: google/cloud-sdk
   args: ['gcloud', 'run', 'deploy', 'gitlab-parser',
-         '--image', 'gcr.io/$PROJECT_ID/gitlab-parser:${_TAG}',
+         '--image', '${_GCR_DOMAIN}/$PROJECT_ID/gitlab-parser:${_TAG}',
          '--region', '${_REGION}',
          '--platform', 'managed'
   ]
@@ -36,5 +36,5 @@ steps:
   waitFor: push
 
 images: [
-  'gcr.io/$PROJECT_ID/gitlab-parser'
+  '${_GCR_DOMAIN}/$PROJECT_ID/gitlab-parser'
 ]

--- a/bq-workers/new-source-template/cloudbuild.yaml
+++ b/bq-workers/new-source-template/cloudbuild.yaml
@@ -16,19 +16,19 @@ steps:
 - # Build new-source worker image
   name: gcr.io/cloud-builders/docker:latest
   args: ['build', 
-         '--tag=gcr.io/$PROJECT_ID/${_SOURCE}-parser', '.']
+         '--tag=${_GCR_DOMAIN}/$PROJECT_ID/${_SOURCE}-parser', '.']
   id: build
 
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/${_SOURCE}-parser']
+  args: ['push', '${_GCR_DOMAIN}/$PROJECT_ID/${_SOURCE}-parser']
   waitFor: build
   id: push
 
 - # Deploy to Cloud Run
   name: google/cloud-sdk
   args: ['gcloud', 'run', 'deploy', '${_SOURCE}-parser',
-         '--image', 'gcr.io/$PROJECT_ID/${_SOURCE}-parser',
+         '--image', '${_GCR_DOMAIN}/$PROJECT_ID/${_SOURCE}-parser',
          '--region', '${_REGION}',
          '--platform', 'managed'
   ]
@@ -36,5 +36,5 @@ steps:
   waitFor: push
 
 images: [
-  'gcr.io/$PROJECT_ID/${_SOURCE}-parser'
+  '${_GCR_DOMAIN}/$PROJECT_ID/${_SOURCE}-parser'
 ]

--- a/bq-workers/pagerduty-parser/cloudbuild.yaml
+++ b/bq-workers/pagerduty-parser/cloudbuild.yaml
@@ -16,19 +16,19 @@ steps:
 - # Build pagerduty-parser image
   name: gcr.io/cloud-builders/docker:latest
   args: ['build', 
-         '--tag=gcr.io/$PROJECT_ID/pagerduty-parser:${_TAG}', '.']
+         '--tag=${_GCR_DOMAIN}/$PROJECT_ID/pagerduty-parser:${_TAG}', '.']
   id: build
 
 - # Push the container image to Artifact Registry
   name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/default/pagerduty-parser:${_TAG}']
+  args: ['push', '${_GCR_DOMAIN}/$PROJECT_ID/default/pagerduty-parser:${_TAG}']
   waitFor: build
   id: push
 
 - # Deploy to Cloud Run
   name: google/cloud-sdk
   args: ['gcloud', 'run', 'deploy', 'pagerduty-parser',
-         '--image', 'gcr.io/$PROJECT_ID/default/pagerduty-parser:${_TAG}',
+         '--image', '${_GCR_DOMAIN}/$PROJECT_ID/default/pagerduty-parser:${_TAG}',
          '--region', '${_FOURKEYS_REGION}',
          '--platform', 'managed'
   ]
@@ -36,5 +36,5 @@ steps:
   waitFor: push
 
 images: [
-  'gcr.io/$PROJECT_ID/pagerduty-parser:${_TAG}'
+  '${_GCR_DOMAIN}/$PROJECT_ID/pagerduty-parser:${_TAG}'
 ]

--- a/bq-workers/parsers.cloudbuild.yaml
+++ b/bq-workers/parsers.cloudbuild.yaml
@@ -17,17 +17,18 @@ steps:
   name: gcr.io/cloud-builders/docker:latest
   dir: ${_SERVICE}-parser
   args: ['build', 
-         '--tag=gcr.io/$PROJECT_ID/${_SERVICE}-parser:${_TAG}', '.']
+         '--tag=${_GCR_DOMAIN}/$PROJECT_ID/${_SERVICE}-parser:${_TAG}', '.']
   id: build
 
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/${_SERVICE}-parser:${_TAG}']
+  args: ['push', '${_GCR_DOMAIN}/$PROJECT_ID/${_SERVICE}-parser:${_TAG}']
   waitFor: build
   id: push
 
 images: [
-  'gcr.io/$PROJECT_ID/${_SERVICE}-parser:${_TAG}'
+  '${_GCR_DOMAIN}/$PROJECT_ID/${_SERVICE}-parser:${_TAG}'
 ]
 substitutions:
   _TAG: latest
+  _GCR_DOMAIN: gcr.io

--- a/bq-workers/tekton-parser/cloudbuild.yaml
+++ b/bq-workers/tekton-parser/cloudbuild.yaml
@@ -16,19 +16,19 @@ steps:
 - # Build tekton worker image
   name: gcr.io/cloud-builders/docker:latest
   args: ['build', 
-         '--tag=gcr.io/$PROJECT_ID/tekton-parser', '.']
+         '--tag=${_GCR_DOMAIN}/$PROJECT_ID/tekton-parser', '.']
   id: build
 
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/tekton-parser']
+  args: ['push', '${_GCR_DOMAIN}/$PROJECT_ID/tekton-parser']
   waitFor: build
   id: push
 
 - # Deploy to Cloud Run
   name: google/cloud-sdk
   args: ['gcloud', 'run', 'deploy', 'tekton-parser',
-         '--image', 'gcr.io/$PROJECT_ID/tekton-parser',
+         '--image', '${_GCR_DOMAIN}/$PROJECT_ID/tekton-parser',
          '--region', '${_REGION}',
          '--platform', 'managed'
   ]
@@ -36,5 +36,5 @@ steps:
   waitFor: push
 
 images: [
-  'gcr.io/$PROJECT_ID/tekton-parser'
+  '${_GCR_DOMAIN}/$PROJECT_ID/tekton-parser'
 ]

--- a/dashboard/cloudbuild.yaml
+++ b/dashboard/cloudbuild.yaml
@@ -16,15 +16,16 @@ steps:
 - # Build grafana image
   name: gcr.io/cloud-builders/docker:latest
   args: ['build', '--tag', 
-         'gcr.io/$PROJECT_ID/fourkeys-grafana-dashboard:${_TAG}', '.']
+         '${_GCR_DOMAIN}/$PROJECT_ID/fourkeys-grafana-dashboard:${_TAG}', '.']
   id: build
 
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/fourkeys-grafana-dashboard:${_TAG}']
+  args: ['push', '${_GCR_DOMAIN}/$PROJECT_ID/fourkeys-grafana-dashboard:${_TAG}']
   id: push
 
 # Read more about substitutions 
 # https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
 substitutions:
   _TAG: latest
+  _GCR_DOMAIN: gcr.io

--- a/event-handler/cloudbuild.yaml
+++ b/event-handler/cloudbuild.yaml
@@ -15,17 +15,18 @@
 steps:
 - # Build event_handler image
   name: gcr.io/cloud-builders/docker:latest
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/event-handler:${_TAG}', '.']
+  args: ['build', '--tag=${_GCR_DOMAIN}/$PROJECT_ID/event-handler:${_TAG}', '.']
   id: build
 
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/event-handler:${_TAG}']
+  args: ['push', '${_GCR_DOMAIN}/$PROJECT_ID/event-handler:${_TAG}']
   waitFor: build
   id: push
 
 images: [
-  'gcr.io/$PROJECT_ID/event-handler:${_TAG}'
+  '${_GCR_DOMAIN}/$PROJECT_ID/event-handler:${_TAG}'
 ]
 substitutions:
   _TAG: latest
+  _GCR_DOMAIN: gcr.io

--- a/setup/README.md
+++ b/setup/README.md
@@ -36,6 +36,9 @@ To deploy Four Keys with Terraform, you will first need:
    gcloud builds submit event-handler --config=event-handler/cloudbuild.yaml --project $PROJECT_ID
    ```
 
+> If you're restricted to using GCP services in certain regions you can override the use of gcr.io with a local domain like eu.gcr.io by adding `--substitutions=_GCR_DOMAIN=eu.gcr.io` to both gcloud builds commands above and any parsers (next step).
+> You'll also need to add the relevant URLs as variables in your `terraform/example/terraform.tfvars` file.
+
 1. Use Cloud Build to build and push containers to Google Container Registry for the parsers you plan to use. See the [`bq-workers`](../bq-workers/) for available options. GitHub for example:
    ```
    gcloud builds submit bq-workers --config=bq-workers/parsers.cloudbuild.yaml --project $PROJECT_ID --substitutions=_SERVICE=github


### PR DESCRIPTION
We're restricted by corporate policy to using services hosted within Europe, so trying to push a build to gcr.io causes an error message.
This lets us build to eu.gcr.io instead, which is allowed.

For reference, other regional domains: https://cloud.google.com/container-registry/docs/pushing-and-pulling#add-registry