### PR TITLE
Bump Python version to 3.10 (Fixes #454)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.7'
+          python-version: '3.10'
       - run: pip install nox
       - run: python3 -m nox

--- a/bq-workers/argocd-parser/Dockerfile
+++ b/bq-workers/argocd-parser/Dockerfile
@@ -15,7 +15,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.7
+FROM python:3.10
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True

--- a/bq-workers/argocd-parser/requirements.txt
+++ b/bq-workers/argocd-parser/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.0.3
-gunicorn>=20.1.0,<21.0.0
+Flask==2.3.2
+gunicorn==20.1.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared
 protobuf==3.20.2

--- a/bq-workers/argocd-parser/requirements.txt
+++ b/bq-workers/argocd-parser/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.0.3
-gunicorn==19.9.0
+gunicorn>=20.1.0,<21.0.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared
 protobuf==3.20.2

--- a/bq-workers/circleci-parser/Dockerfile
+++ b/bq-workers/circleci-parser/Dockerfile
@@ -15,7 +15,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.7
+FROM python:3.10
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True

--- a/bq-workers/circleci-parser/requirements.txt
+++ b/bq-workers/circleci-parser/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.0.3
-gunicorn>=20.1.0,<21.0.0
+Flask==2.3.2
+gunicorn==20.1.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared
 protobuf==3.20.2

--- a/bq-workers/circleci-parser/requirements.txt
+++ b/bq-workers/circleci-parser/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.0.3
-gunicorn==19.9.0
+gunicorn>=20.1.0,<21.0.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared
 protobuf==3.20.2

--- a/bq-workers/cloud-build-parser/Dockerfile
+++ b/bq-workers/cloud-build-parser/Dockerfile
@@ -15,7 +15,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.7
+FROM python:3.10
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True

--- a/bq-workers/cloud-build-parser/requirements.txt
+++ b/bq-workers/cloud-build-parser/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.0.3
-gunicorn>=20.1.0,<21.0.0
+Flask==2.3.2
+gunicorn==20.1.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared
 protobuf==3.20.2

--- a/bq-workers/cloud-build-parser/requirements.txt
+++ b/bq-workers/cloud-build-parser/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.0.3
-gunicorn==19.9.0
+gunicorn>=20.1.0,<21.0.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared
 protobuf==3.20.2

--- a/bq-workers/github-parser/Dockerfile
+++ b/bq-workers/github-parser/Dockerfile
@@ -15,7 +15,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.7
+FROM python:3.10
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True

--- a/bq-workers/github-parser/requirements.txt
+++ b/bq-workers/github-parser/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.0.3
-gunicorn>=20.1.0,<21.0.0
+Flask==2.3.2
+gunicorn==20.1.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared
 protobuf==3.20.2

--- a/bq-workers/github-parser/requirements.txt
+++ b/bq-workers/github-parser/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.0.3
-gunicorn==19.9.0
+gunicorn>=20.1.0,<21.0.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared
 protobuf==3.20.2

--- a/bq-workers/gitlab-parser/Dockerfile
+++ b/bq-workers/gitlab-parser/Dockerfile
@@ -15,7 +15,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.7
+FROM python:3.10
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True

--- a/bq-workers/gitlab-parser/requirements.txt
+++ b/bq-workers/gitlab-parser/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.0.3
-gunicorn>=20.1.0,<21.0.0
+Flask==2.3.2
+gunicorn==20.1.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared
 protobuf==3.20.2

--- a/bq-workers/gitlab-parser/requirements.txt
+++ b/bq-workers/gitlab-parser/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.0.3
-gunicorn==19.9.0
+gunicorn>=20.1.0,<21.0.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared
 protobuf==3.20.2

--- a/bq-workers/new-source-template/Dockerfile
+++ b/bq-workers/new-source-template/Dockerfile
@@ -15,7 +15,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.7
+FROM python:3.10
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True

--- a/bq-workers/new-source-template/requirements.txt
+++ b/bq-workers/new-source-template/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.0.3
-gunicorn>=20.1.0,<21.0.0
+Flask==2.3.2
+gunicorn==20.1.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared
 protobuf==3.20.2

--- a/bq-workers/new-source-template/requirements.txt
+++ b/bq-workers/new-source-template/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.0.3
-gunicorn==19.9.0
+gunicorn>=20.1.0,<21.0.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared
 protobuf==3.20.2

--- a/bq-workers/pagerduty-parser/Dockerfile
+++ b/bq-workers/pagerduty-parser/Dockerfile
@@ -15,7 +15,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.7
+FROM python:3.10
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True

--- a/bq-workers/pagerduty-parser/requirements.txt
+++ b/bq-workers/pagerduty-parser/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.0.3
-gunicorn>=20.1.0,<21.0.0
+Flask==2.3.2
+gunicorn==20.1.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared
 protobuf==3.20.2

--- a/bq-workers/pagerduty-parser/requirements.txt
+++ b/bq-workers/pagerduty-parser/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.0.3
-gunicorn==19.9.0
+gunicorn>=20.1.0,<21.0.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared
 protobuf==3.20.2

--- a/bq-workers/tekton-parser/Dockerfile
+++ b/bq-workers/tekton-parser/Dockerfile
@@ -15,7 +15,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.7
+FROM python:3.10
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True

--- a/bq-workers/tekton-parser/requirements.txt
+++ b/bq-workers/tekton-parser/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.0.3
-gunicorn==19.9.0
+gunicorn>=20.1.0,<21.0.0
 google-cloud-bigquery==1.23.1
 cloudevents==1.2.0
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared

--- a/bq-workers/tekton-parser/requirements.txt
+++ b/bq-workers/tekton-parser/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.0.3
-gunicorn>=20.1.0,<21.0.0
+Flask==2.3.2
+gunicorn==20.1.0
 google-cloud-bigquery==1.23.1
 cloudevents==1.2.0
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared

--- a/event-handler/Dockerfile
+++ b/event-handler/Dockerfile
@@ -15,7 +15,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.7-slim
+FROM python:3.10-slim
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True

--- a/event-handler/requirements.txt
+++ b/event-handler/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.0.3
-gunicorn>=20.1.0,<21.0.0
+Flask==2.3.2
+gunicorn==20.1.0
 google-cloud-pubsub==1.1.0
 google-cloud-secret-manager==0.1.0

--- a/event-handler/requirements.txt
+++ b/event-handler/requirements.txt
@@ -1,4 +1,4 @@
 Flask==2.0.3
-gunicorn==19.9.0
+gunicorn>=20.1.0,<21.0.0
 google-cloud-pubsub==1.1.0
 google-cloud-secret-manager==0.1.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -71,7 +71,7 @@ def _session_tests(session, folder):
     )
 
 
-@nox.session(python=["3.7"])
+@nox.session(python=["3.10"])
 @nox.parametrize("folder", FOLDERS)
 def py(session, folder):
     """Runs py.test for a folder using the specified version of Python."""

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
 mock==4.0.2
-pytest==5.3.2
+pytest==6.*


### PR DESCRIPTION
This PR: 
* bumps the python version from 3.7 to 3.10
* bumps gunicorn and pytest for compatibility with 3.10
* bumps Flask to resolve vulnerability flagged by dependabot

Fixes #454