### PR TITLE
Use param=value while accessing secret version

### DIFF
--- a/event-handler/sources.py
+++ b/event-handler/sources.py
@@ -120,7 +120,7 @@ def get_secret(project_name, secret_name, version_num):
         name = client.secret_version_path(
             project_name, secret_name, version_num
         )
-        secret = client.access_secret_version(name)
+        secret = client.access_secret_version(name=name)
         return secret.payload.data
     except Exception as e:
         print(e)


### PR DESCRIPTION
I was getting the following error while executing the event_hander on local
`Invalid constructor input for AccessSecretVersionRequest: 'projects/1234567890/secrets/event-handler/versions/latest'
`
after reading the [google api docs](https://codelabs.developers.google.com/codelabs/secret-manager-python#6) for accessing secret manager, i found that instead of passing the `name` param [directly](https://github.com/dora-team/fourkeys/blob/main/event-handler/sources.py#L123) we should pass it like name=value `name=name`.

after this change i don't get the error.

