### PR TITLE
Fix missing ArgoCD support in sources.py

### DIFF
--- a/event-handler/sources.py
+++ b/event-handler/sources.py
@@ -145,6 +145,9 @@ def get_source(headers):
     if "X-Pagerduty-Signature" in headers:
         return "pagerduty"
 
+    if "Argo-CD" in headers.get("User-Agent", ""):
+        return "argocd"
+
     return headers.get("User-Agent")
 
 
@@ -163,5 +166,8 @@ AUTHORIZED_SOURCES = {
         ),
     "pagerduty": EventSource(
         "X-Pagerduty-Signature", pagerduty_verification
+        ),
+    "argocd": EventSource(
+        "Argo-Signature", simple_token_verification
         ),
 }


### PR DESCRIPTION
ArgoCD support was merged in #286, but `event-handler/sources.py` in the current main branch doesn't support ArgoCD.
This PR fixes missing ArgoCD support in the `event-handler/sources.py`.