### PR TITLE
Fix event insert sample data error with module six not found

### DIFF
--- a/event-handler/requirements.txt
+++ b/event-handler/requirements.txt
@@ -1,4 +1,4 @@
 Flask==2.3.2
 gunicorn==20.1.0
-google-cloud-pubsub==1.1.0
+google-cloud-pubsub==1.7.2
 google-cloud-secret-manager==0.1.0


### PR DESCRIPTION
**Issue**: 
Fail to insert sample data with `ModuleNotFoundError` for 'six' module

**Details**:
Encountered a 'six' module not found error within the `google/cloud/pubsub_v1` module in event handler

**Reproduction Steps**:
1. Deploy Four Keys.
2. Insert sample data using the following command:
```bash
python3 data-generator/generate_data.py --vc_system=github
```

### Stack trace
ModuleNotFoundError: No module named 'six'
at .<module> ( /usr/local/lib/python3.10/site-packages/google/cloud/pubsub_v1/publisher/client.py:22 )
at .<module> ( /usr/local/lib/python3.10/site-packages/google/cloud/pubsub_v1/publisher/__init__.py:17 )
at .<module> ( /usr/local/lib/python3.10/site-packages/google/cloud/pubsub_v1/__init__.py:18 )
at .<module> ( /app/event_handler.py:20 )
at ._call_with_frames_removed ( <frozen importlib._bootstrap>:241 )
at .exec_module ( <frozen importlib._bootstrap_external>:883 )
at ._load_unlocked ( <frozen importlib._bootstrap>:688 )
at ._find_and_load_unlocked ( <frozen importlib._bootstrap>:1006 )
at ._find_and_load ( <frozen importlib._bootstrap>:1027 )
at ._gcd_import ( <frozen importlib._bootstrap>:1050 )
at .import_module ( /usr/local/lib/python3.10/importlib/__init__.py:126 )
at .import_app ( /usr/local/lib/python3.10/site-packages/gunicorn/util.py:359 )
at .load_wsgiapp ( /usr/local/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py:48 )
at .load ( /usr/local/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py:58 )
at .wsgi ( /usr/local/lib/python3.10/site-packages/gunicorn/app/base.py:67 )
at .load_wsgi ( /usr/local/lib/python3.10/site-packages/gunicorn/workers/base.py:146 )
at .init_process ( /usr/local/lib/python3.10/site-packages/gunicorn/workers/base.py:134 )
at .init_process ( /usr/local/lib/python3.10/site-packages/gunicorn/workers/gthread.py:92 )
at .spawn_worker ( /usr/local/lib/python3.10/site-packages/gunicorn/arbiter.py:589 )

### How to fix this error
I updated google-cloud-pubsub to 1.7.2 then the issue has resolved and succeeded to insert sample data