### PR TITLE
feat(bigquery): add optional project_id parameter to insert_row_into_…

### DIFF
--- a/shared/shared.py
+++ b/shared/shared.py
@@ -17,12 +17,16 @@ import json
 from google.cloud import bigquery
 
 
-def insert_row_into_bigquery(event):
+def insert_row_into_bigquery(event, **kwargs):
+    project_id = kwargs.get('project_id', None)
     if not event:
         raise Exception("No data to insert")
 
     # Set up bigquery instance
-    client = bigquery.Client()
+    if project_id is None :
+        client = bigquery.Client()
+    else:
+        client = bigquery.Client(project=project_id)
     dataset_id = "four_keys"
     table_id = "events_raw"
 
@@ -55,12 +59,16 @@ def insert_row_into_bigquery(event):
             print(json.dumps(entry))
 
 
-def insert_row_into_events_enriched(event):
+def insert_row_into_events_enriched(event, **kwargs):
+    project_id = kwargs.get('project_id', None)
     if not event:
         raise Exception("No data to insert")
 
     # Set up bigquery instance
-    client = bigquery.Client()
+    if project_id is None :
+        client = bigquery.Client()
+    else:
+        client = bigquery.Client(project=project_id)
     dataset_id = "four_keys"
     table_id = "events_enriched"
 


### PR DESCRIPTION
…bigquery and insert_row_into_events_enriched

This commit allows users to specify a GCP project ID when calling insert_row_into_bigquery and *insert_row_into_events_enriched without affecting existing function calls. The project_id is an optional keyword argument, and if not provided, the function will behave as it did prior to this commit, using the default project ID.